### PR TITLE
Jython 270 support

### DIFF
--- a/odoorpc/db.py
+++ b/odoorpc/db.py
@@ -23,7 +23,7 @@ import base64
 import io
 import sys
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     def encode2bytes(data):
         return data
 # Python >= 3

--- a/odoorpc/env.py
+++ b/odoorpc/env.py
@@ -288,7 +288,7 @@ class Environment(object):
         """
         cls_name = model.replace('.', '_')
         # Hack for Python 2 (no need to do this for Python 3)
-        if sys.version_info.major < 3:
+        if sys.version_info[0] < 3:
             if isinstance(cls_name, unicode):
                 cls_name = cls_name.encode('utf-8')
         # Retrieve server fields info and generate corresponding local fields

--- a/odoorpc/fields.py
+++ b/odoorpc/fields.py
@@ -41,7 +41,7 @@ def is_int(value):
 
 
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     def is_string(value):
         """Return `True` if ``value`` is a string."""
         return isinstance(value, basestring)

--- a/odoorpc/models.py
+++ b/odoorpc/models.py
@@ -29,7 +29,7 @@ import sys
 from odoorpc import error
 
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     NORMALIZED_TYPES = (int, long, str, unicode)
 # Python >= 3
 else:

--- a/odoorpc/report.py
+++ b/odoorpc/report.py
@@ -25,7 +25,7 @@ import base64
 import io
 import sys
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     def encode2bytes(data):
         return data
 # Python >= 3

--- a/odoorpc/rpc/__init__.py
+++ b/odoorpc/rpc/__init__.py
@@ -26,7 +26,7 @@ These methods can be accessed from the connectors of this module.
 """
 import sys
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     from urllib2 import build_opener, HTTPCookieProcessor
     from cookielib import CookieJar
 # Python >= 3

--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -23,7 +23,7 @@ import json
 import random
 import sys
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     from urllib2 import build_opener, HTTPCookieProcessor, Request
     from cookielib import CookieJar
 

--- a/odoorpc/session.py
+++ b/odoorpc/session.py
@@ -25,7 +25,7 @@ import os
 import stat
 import sys
 # Python 2
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     from ConfigParser import SafeConfigParser as ConfigParser
 # Python >= 3
 else:


### PR DESCRIPTION
These changes allow the current jython version (2.7.0) to work with OdooRPC.
This is due to a bug in Jython. http://bugs.jython.org/issue2380
Jython has a CPython 2.6 style sys.version_info tuple.