### PR TITLE
Add __contains__ to Environment.

### DIFF
--- a/odoorpc/env.py
+++ b/odoorpc/env.py
@@ -281,6 +281,12 @@ class Environment(object):
         env._registry = self._registry
         return env
 
+    def __contains__(self, model):
+        """Check if the given `model` exists on the server."""
+        model_exists = self._odoo.execute('ir.model', 'search',
+                                          [('model', '=', model)])
+        return bool(model_exists)
+
     def _create_model_class(self, model):
         """Generate the model proxy class.
 

--- a/odoorpc/tests/test_env.py
+++ b/odoorpc/tests/test_env.py
@@ -72,4 +72,8 @@ class TestEnvironment(LoginTestCase):
         self.assertEqual(record._name, 'res.lang')
         self.assertEqual(record.code, 'en_US')
 
+    def test_env_contains(self):
+        self.assertIn('res.partner', self.odoo.env)
+        self.assertNotIn('does.not.exist', self.odoo.env)
+
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
Without this, trying to use "'x' in odoo.env" results in a hard to understand
error because Python tries to treat it as a sequence and tries the equivalent
of odoo.env[0].

Supersedes #15.