### PR TITLE
[IMP] Remove timeout int check.

### DIFF
--- a/odoorpc/odoo.py
+++ b/odoorpc/odoo.py
@@ -73,9 +73,10 @@ class ODOO(object):
         except ValueError:
             raise ValueError("The port must be an integer")
         try:
-            timeout = int(timeout)
+            if timeout is not None:
+                timeout = float(timeout)
         except ValueError:
-            raise ValueError("The timeout must be an integer")
+            raise ValueError("The timeout must be a float")
         self._host = host
         self._port = port
         self._protocol = protocol

--- a/odoorpc/tests/test_init.py
+++ b/odoorpc/tests/test_init.py
@@ -35,6 +35,16 @@ class TestInit(BaseTestCase):
         self.assertEqual(odoo.port, self.env['port'])
         self.assertEqual(odoo.config['timeout'], 42)
 
+    def test_init_timeout_none(self):
+        odoo = odoorpc.ODOO(
+            self.env['host'], self.env['protocol'], self.env['port'], None)
+        self.assertIs(odoo.config['timeout'], None)
+
+    def test_init_timeout_float(self):
+        odoo = odoorpc.ODOO(
+            self.env['host'], self.env['protocol'], self.env['port'], 23.42)
+        self.assertEqual(odoo.config['timeout'], 23.42)
+
     def test_init_wrong_protocol(self):
         self.assertRaises(
             ValueError,


### PR DESCRIPTION
floats and `None` also work as parameters to `sock.settimeout`. If someone passes
an invalid value, this is already handled by `socket.py`:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/florian/proj/odoorpc/odoorpc/odoo.py", line 90, in __init__
    self._host, self._port, timeout, version)
  File "/home/florian/proj/odoorpc/odoorpc/rpc/__init__.py", line 171, in __init__
    self._proxy_json, self._proxy_http = self._get_proxies()
  File "/home/florian/proj/odoorpc/odoorpc/rpc/__init__.py", line 186, in _get_proxies
    result = proxy_json.web.webclient.version_info()['result']
  File "/home/florian/proj/odoorpc/odoorpc/rpc/jsonrpclib.py", line 135, in __call__
    return self._rpc(self._url, kwargs)
  File "/home/florian/proj/odoorpc/odoorpc/rpc/jsonrpclib.py", line 91, in __call__
    response = self._opener.open(request, timeout=self._timeout)
  File "/usr/lib/python3.4/urllib/request.py", line 455, in open
    response = self._open(req, data)
  File "/usr/lib/python3.4/urllib/request.py", line 473, in _open
    '_open', req)
  File "/usr/lib/python3.4/urllib/request.py", line 433, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.4/urllib/request.py", line 1202, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.4/urllib/request.py", line 1174, in do_open
    h.request(req.get_method(), req.selector, req.data, headers)
  File "/usr/lib/python3.4/http/client.py", line 1090, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.4/http/client.py", line 1128, in _send_request
    self.endheaders(body)
  File "/usr/lib/python3.4/http/client.py", line 1086, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python3.4/http/client.py", line 924, in _send_output
    self.send(msg)
  File "/usr/lib/python3.4/http/client.py", line 859, in send
    self.connect()
  File "/usr/lib/python3.4/http/client.py", line 836, in connect
    self.timeout, self.source_address)
  File "/usr/lib/python3.4/socket.py", line 497, in create_connection
    sock.settimeout(timeout)
TypeError: a float is required
```