### PR TITLE
[IMP] Adds support for passing a custom URL opener

### DIFF
--- a/odoorpc/odoo.py
+++ b/odoorpc/odoo.py
@@ -62,7 +62,7 @@ class ODOO(object):
     """
 
     def __init__(self, host='localhost', protocol='jsonrpc',
-                 port=8069, timeout=120, version=None):
+                 port=8069, timeout=120, version=None, opener=None):
         if protocol not in ['jsonrpc', 'jsonrpc+ssl']:
             txt = ("The protocol '{0}' is not supported by the ODOO class. "
                    "Please choose a protocol among these ones: {1}")
@@ -88,7 +88,7 @@ class ODOO(object):
         # Instanciate the server connector
         try:
             self._connector = rpc.PROTOCOLS[protocol](
-                self._host, self._port, timeout, version)
+                self._host, self._port, timeout, version, opener=opener)
         except rpc.error.ConnectorError as exc:
             raise error.InternalError(exc.message)
         # Dictionary of configuration options

--- a/odoorpc/rpc/__init__.py
+++ b/odoorpc/rpc/__init__.py
@@ -183,14 +183,16 @@ class ConnectorJSONRPC(Connector):
         True
     """
     def __init__(self, host, port=8069, timeout=120, version=None,
-                 deserialize=True):
+                 deserialize=True, opener=None):
         super(ConnectorJSONRPC, self).__init__(host, port, timeout, version)
         self.deserialize = deserialize
         # One URL opener (with cookies handling) shared between
         # JSON and HTTP requests
-        cookie_jar = CookieJar()
-        self._opener = build_opener(
-            HTTPCookieProcessor(cookie_jar))
+        if opener is None:
+            cookie_jar = CookieJar()
+            opener = build_opener(
+                HTTPCookieProcessor(cookie_jar))
+        self._opener = opener
         self._proxy_json, self._proxy_http = self._get_proxies()
 
     def _get_proxies(self):
@@ -250,8 +252,9 @@ class ConnectorJSONRPCSSL(ConnectorJSONRPC):
         ...     cnt = rpc.ConnectorJSONRPCSSL(HOST, port=PORT)
     """
     def __init__(self, host, port=8069, timeout=120, version=None,
-                 deserialize=True):
-        super(ConnectorJSONRPCSSL, self).__init__(host, port, timeout, version)
+                 deserialize=True, opener=None):
+        super(ConnectorJSONRPCSSL, self).__init__(
+            host, port, timeout, version, opener=opener)
         self._proxy_json, self._proxy_http = self._get_proxies()
 
     @property

--- a/odoorpc/tests/test_init.py
+++ b/odoorpc/tests/test_init.py
@@ -3,10 +3,11 @@
 import sys
 # Python 2
 if sys.version_info.major < 3:
-    from urllib2 import URLError
+    from urllib2 import BaseHandler, URLError, build_opener
 # Python >= 3
 else:
     from urllib.error import URLError
+    from urllib.request import BaseHandler, build_opener
 
 from odoorpc.tests import BaseTestCase
 import odoorpc
@@ -34,6 +35,17 @@ class TestInit(BaseTestCase):
         self.assertEqual(odoo.protocol, self.env['protocol'])
         self.assertEqual(odoo.port, self.env['port'])
         self.assertEqual(odoo.config['timeout'], 42)
+
+    def test_init_opener(self):
+        # Opener
+        opener = build_opener(BaseHandler)
+        odoo = odoorpc.ODOO(
+            self.env['host'], self.env['protocol'], self.env['port'],
+            opener=opener)
+        connector = odoo._connector
+        self.assertIs(connector._opener, opener)
+        self.assertIs(connector._proxy_http._opener, opener)
+        self.assertIs(connector._proxy_json._opener, opener)
 
     def test_init_timeout_none(self):
         odoo = odoorpc.ODOO(


### PR DESCRIPTION
Hello,

this adds support for passing a custom URL opener to `odoorpc.ODOO`. This in turn passes it down to `ConnectorJSONRPC` or `ConnectorJSONRPCSSL` which then pass it to `ProxyHTTP` and `ProxyJSON`.

Use case -- some people add basic HTTP authentication in front of Odoo using nginx or Apache. In order to use such an Odoo instance with OdooRPC, one needs to use a custom URL opener with eg. [`HTTPBasicAuthHandler`](https://docs.python.org/3.2/library/urllib.request.html#urllib.request.HTTPBasicAuthHandler). However, there is no direct way on how to pass a custom URL opener to `odoorpc.ODOO`, and setting it later (after instantiating an `odoorpc.ODOO`) is not always an option, because the Odoo RPC will be called during instantiation (if `version` is not set [[link]](https://github.com/osiell/odoorpc/blob/master/odoorpc/rpc/__init__.py#L208)).

Any feedback regarding the PR would be very appreciated.